### PR TITLE
Fix memory usage report

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -247,12 +247,19 @@ def get_mem():
     Get memory usage
     """
     try:
-        pipe = os.popen("free -tmo | " + "grep 'Mem' | " + "awk '{print $2,$4}'")
+        pipe = os.popen(
+            "free -tmo | " + "grep 'Mem' | " + "awk '{print $2,$4,$6,$7}'")
         data = pipe.read().strip().split()
         pipe.close()
 
         allmem = int(data[0])
         freemem = int(data[1])
+        buffers = int(data[2])
+        cachedmem = int(data[3])
+
+        # Memory in buffers + cached is actually available, so we count it
+        # as free. See http://www.linuxatemyram.com/ for details
+        freemem += buffers + cachedmem
 
         percent = (100 - ((freemem * 100) / allmem))
         usage = (allmem - freemem)


### PR DESCRIPTION
This is a very small changeset that addresses an issue I ran into today: pydash was showing that all my memory was used and none of it was free when I actually had about 90% of free memory in my system.

The source of this issue was the fact that the amount of free memory reported by the command `free` is not the actual available memory in the system. Linux borrows unused memory for disk caching, so that needs to be accounted for and the memory used for cache and buffers should be counted as free memory. 

This was easily noticeable in high I/O systems where a couple of minutes after reboot pydash would report all the system memory being used while most of it was actually still available.

There's a lot more details about this here: http://www.linuxatemyram.com/

Hope this helps!
